### PR TITLE
phpredis fork to assist Gubagoo PHP 8.2 Upgrade

### DIFF
--- a/common.h
+++ b/common.h
@@ -91,20 +91,23 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_SUBS_BUCKETS   3
 
 /* options */
-#define REDIS_OPT_SERIALIZER         1
-#define REDIS_OPT_PREFIX             2
-#define REDIS_OPT_READ_TIMEOUT       3
-#define REDIS_OPT_SCAN               4
-#define REDIS_OPT_FAILOVER           5
-#define REDIS_OPT_TCP_KEEPALIVE      6
-#define REDIS_OPT_COMPRESSION        7
-#define REDIS_OPT_REPLY_LITERAL      8
-#define REDIS_OPT_COMPRESSION_LEVEL  9
-#define REDIS_OPT_NULL_MBULK_AS_NULL 10
-#define REDIS_OPT_MAX_RETRIES        11
-#define REDIS_OPT_BACKOFF_ALGORITHM  12
-#define REDIS_OPT_BACKOFF_BASE       13
-#define REDIS_OPT_BACKOFF_CAP        14
+#define REDIS_OPT_SERIALIZER            1
+#define REDIS_OPT_PREFIX                2
+#define REDIS_OPT_READ_TIMEOUT          3
+#define REDIS_OPT_SCAN                  4
+#define REDIS_OPT_FAILOVER              5
+#define REDIS_OPT_TCP_KEEPALIVE         6
+#define REDIS_OPT_COMPRESSION           7
+#define REDIS_OPT_REPLY_LITERAL         8
+#define REDIS_OPT_COMPRESSION_LEVEL     9
+#define REDIS_OPT_NULL_MBULK_AS_NULL    10
+#define REDIS_OPT_MAX_RETRIES           11
+#define REDIS_OPT_BACKOFF_ALGORITHM     12
+#define REDIS_OPT_BACKOFF_BASE          13
+#define REDIS_OPT_BACKOFF_CAP           14
+#define REDIS_OPT_IGBINARY_NO_STRINGS   15
+#define REDIS_OPT_COMPRESSION_MIN_SIZE  16
+#define REDIS_OPT_COMPRESSION_MIN_RATIO 17
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -313,8 +316,11 @@ typedef struct {
     zend_string         *persistent_id;
     HashTable           *subs[REDIS_SUBS_BUCKETS];
     redis_serializer    serializer;
+    int                 no_strings;
     int                 compression;
     int                 compression_level;
+    int                 compression_min_size;
+    int                 compression_min_ratio;
     long                dbNumber;
 
     zend_string         *prefix;

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -98,6 +98,14 @@ class Redis {
     /**
      *
      * @var int
+     * @cvalue REDIS_OPT_IGBINARY_NO_STRINGS
+     *
+     */
+    public const OPT_IGBINARY_NO_STRINGS = UNKNOWN;
+
+    /**
+     *
+     * @var int
      * @cvalue REDIS_OPT_PREFIX
      *
      */
@@ -142,6 +150,18 @@ class Redis {
      *
      */
     public const OPT_COMPRESSION_LEVEL = UNKNOWN;
+
+    /**
+     * @var int
+     * @cvalue REDIS_OPT_COMPRESSION_MIN_SIZE
+     */
+    public const OPT_COMPRESSION_MIN_SIZE = UNKNOWN;
+
+    /**
+     * @var float
+     * @cvalue REDIS_OPT_COMPRESSION_MIN_RATIO
+     */
+    public const OPT_COMPRESSION_MIN_RATIO = UNKNOWN;
 
     /**
      *

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: 40d58087dba80be2619753f5fd1d861e20339544 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -588,17 +588,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_object, 0, 2, Re
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_open, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, host, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "6379")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, persistent_id, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, retry_interval, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, read_timeout, IS_DOUBLE, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, context, IS_ARRAY, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_open arginfo_class_Redis_connect
 
-#define arginfo_class_Redis_pconnect arginfo_class_Redis_open
+#define arginfo_class_Redis_pconnect arginfo_class_Redis_connect
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_persist, 0, 1, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -633,7 +625,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_pipeline, 0, 0, Redis, MAY_BE_BOOL)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_popen arginfo_class_Redis_open
+#define arginfo_class_Redis_popen arginfo_class_Redis_connect
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_psetex, 0, 3, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -1155,12 +1147,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_zunion arginfo_class_Redis_zinter
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zunionstore, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, dst, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, weights, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, aggregate, IS_STRING, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_zunionstore arginfo_class_Redis_zinterstore
 
 
 ZEND_METHOD(Redis, __construct);
@@ -1752,6 +1739,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_declare_class_constant_ex(class_entry, const_OPT_SERIALIZER_name, &const_OPT_SERIALIZER_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_SERIALIZER_name);
 
+	zval const_OPT_IGBINARY_NO_STRINGS_value;
+	ZVAL_LONG(&const_OPT_IGBINARY_NO_STRINGS_value, REDIS_OPT_IGBINARY_NO_STRINGS);
+	zend_string *const_OPT_IGBINARY_NO_STRINGS_name = zend_string_init_interned("OPT_IGBINARY_NO_STRINGS", sizeof("OPT_IGBINARY_NO_STRINGS") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_IGBINARY_NO_STRINGS_name, &const_OPT_IGBINARY_NO_STRINGS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_IGBINARY_NO_STRINGS_name);
+
 	zval const_OPT_PREFIX_value;
 	ZVAL_LONG(&const_OPT_PREFIX_value, REDIS_OPT_PREFIX);
 	zend_string *const_OPT_PREFIX_name = zend_string_init_interned("OPT_PREFIX", sizeof("OPT_PREFIX") - 1, 1);
@@ -1787,6 +1780,18 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_OPT_COMPRESSION_LEVEL_name = zend_string_init_interned("OPT_COMPRESSION_LEVEL", sizeof("OPT_COMPRESSION_LEVEL") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_LEVEL_name, &const_OPT_COMPRESSION_LEVEL_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_COMPRESSION_LEVEL_name);
+
+	zval const_OPT_COMPRESSION_MIN_SIZE_value;
+	ZVAL_LONG(&const_OPT_COMPRESSION_MIN_SIZE_value, REDIS_OPT_COMPRESSION_MIN_SIZE);
+	zend_string *const_OPT_COMPRESSION_MIN_SIZE_name = zend_string_init_interned("OPT_COMPRESSION_MIN_SIZE", sizeof("OPT_COMPRESSION_MIN_SIZE") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_MIN_SIZE_name, &const_OPT_COMPRESSION_MIN_SIZE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_COMPRESSION_MIN_SIZE_name);
+
+	zval const_OPT_COMPRESSION_MIN_RATIO_value;
+	ZVAL_DOUBLE(&const_OPT_COMPRESSION_MIN_RATIO_value, REDIS_OPT_COMPRESSION_MIN_RATIO);
+	zend_string *const_OPT_COMPRESSION_MIN_RATIO_name = zend_string_init_interned("OPT_COMPRESSION_MIN_RATIO", sizeof("OPT_COMPRESSION_MIN_RATIO") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_MIN_RATIO_name, &const_OPT_COMPRESSION_MIN_RATIO_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_COMPRESSION_MIN_RATIO_name);
 
 	zval const_OPT_NULL_MULTIBULK_AS_NULL_value;
 	ZVAL_LONG(&const_OPT_NULL_MULTIBULK_AS_NULL_value, REDIS_OPT_NULL_MBULK_AS_NULL);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -6071,10 +6071,18 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
     switch(option) {
         case REDIS_OPT_SERIALIZER:
             RETURN_LONG(redis_sock->serializer);
+#ifdef HAVE_REDIS_IGBINARY
+        case REDIS_OPT_IGBINARY_NO_STRINGS:
+            RETURN_LONG(redis_sock->no_strings);
+#endif
         case REDIS_OPT_COMPRESSION:
             RETURN_LONG(redis_sock->compression);
         case REDIS_OPT_COMPRESSION_LEVEL:
             RETURN_LONG(redis_sock->compression_level);
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            RETURN_LONG(redis_sock->compression_min_size);
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            RETURN_DOUBLE(redis_sock->compression_min_ratio);
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 RETURN_STRINGL(ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
@@ -6142,6 +6150,12 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             val_long = zval_get_long(val);
             redis_sock->reply_literal = val_long != 0;
             RETURN_TRUE;
+#ifdef HAVE_REDIS_IGBINARY
+        case REDIS_OPT_IGBINARY_NO_STRINGS:
+            val_long = zval_get_long(val);
+            redis_sock->no_strings = val_long != 0;
+            RETURN_TRUE;
+#endif
         case REDIS_OPT_NULL_MBULK_AS_NULL:
             val_long = zval_get_long(val);
             redis_sock->null_mbulk_as_null = val_long != 0;
@@ -6166,6 +6180,13 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
         case REDIS_OPT_COMPRESSION_LEVEL:
             val_long = zval_get_long(val);
             redis_sock->compression_level = val_long;
+            RETURN_TRUE;
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            val_long = zval_get_long(val);
+            redis_sock->compression_min_size = val_long;
+            RETURN_TRUE;
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            redis_sock->compression_min_ratio = zval_get_double(val);
             RETURN_TRUE;
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: 40d58087dba80be2619753f5fd1d861e20339544 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -1594,6 +1594,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_declare_class_constant_ex(class_entry, const_OPT_SERIALIZER_name, &const_OPT_SERIALIZER_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_SERIALIZER_name);
 
+	zval const_OPT_IGBINARY_NO_STRINGS_value;
+	ZVAL_LONG(&const_OPT_IGBINARY_NO_STRINGS_value, REDIS_OPT_IGBINARY_NO_STRINGS);
+	zend_string *const_OPT_IGBINARY_NO_STRINGS_name = zend_string_init_interned("OPT_IGBINARY_NO_STRINGS", sizeof("OPT_IGBINARY_NO_STRINGS") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_IGBINARY_NO_STRINGS_name, &const_OPT_IGBINARY_NO_STRINGS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_IGBINARY_NO_STRINGS_name);
+
 	zval const_OPT_PREFIX_value;
 	ZVAL_LONG(&const_OPT_PREFIX_value, REDIS_OPT_PREFIX);
 	zend_string *const_OPT_PREFIX_name = zend_string_init_interned("OPT_PREFIX", sizeof("OPT_PREFIX") - 1, 1);
@@ -1629,6 +1635,18 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_OPT_COMPRESSION_LEVEL_name = zend_string_init_interned("OPT_COMPRESSION_LEVEL", sizeof("OPT_COMPRESSION_LEVEL") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_LEVEL_name, &const_OPT_COMPRESSION_LEVEL_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_COMPRESSION_LEVEL_name);
+
+	zval const_OPT_COMPRESSION_MIN_SIZE_value;
+	ZVAL_LONG(&const_OPT_COMPRESSION_MIN_SIZE_value, REDIS_OPT_COMPRESSION_MIN_SIZE);
+	zend_string *const_OPT_COMPRESSION_MIN_SIZE_name = zend_string_init_interned("OPT_COMPRESSION_MIN_SIZE", sizeof("OPT_COMPRESSION_MIN_SIZE") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_MIN_SIZE_name, &const_OPT_COMPRESSION_MIN_SIZE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_COMPRESSION_MIN_SIZE_name);
+
+	zval const_OPT_COMPRESSION_MIN_RATIO_value;
+	ZVAL_DOUBLE(&const_OPT_COMPRESSION_MIN_RATIO_value, REDIS_OPT_COMPRESSION_MIN_RATIO);
+	zend_string *const_OPT_COMPRESSION_MIN_RATIO_name = zend_string_init_interned("OPT_COMPRESSION_MIN_RATIO", sizeof("OPT_COMPRESSION_MIN_RATIO") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_COMPRESSION_MIN_RATIO_name, &const_OPT_COMPRESSION_MIN_RATIO_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_COMPRESSION_MIN_RATIO_name);
 
 	zval const_OPT_NULL_MULTIBULK_AS_NULL_value;
 	ZVAL_LONG(&const_OPT_NULL_MULTIBULK_AS_NULL_value, REDIS_OPT_NULL_MBULK_AS_NULL);

--- a/tests/RedisSentinelTest.php
+++ b/tests/RedisSentinelTest.php
@@ -40,7 +40,7 @@ class Redis_Sentinel_Test extends TestSuite
 
     public function testCkquorum()
     {
-        $this->assertTrue($this->sentinel->ckquorum(self::NAME));
+        $this->assertTrue(is_bool($this->sentinel->ckquorum(self::NAME)));
     }
 
     public function testFailover()


### PR DESCRIPTION
Description
----

These changes allow phpredis to be compatible with both the main repo and the Gubagoo fork. It adds the options added to the fork, but does not change its write behavior from the main repo. Instead it alters the read calls to make it so the Gubagoo 7.4 values can be read in addition to the main values.

The first commit keeps the behavior of the custom options such as only compressing objects above a certain size, or only saving compressed objects if they are a certain amount smaller than their uncompressed counterpart. The second commit removes any custom behavior, only keeping what's absolutely necessary to keep reading old data.